### PR TITLE
update naming conventions

### DIFF
--- a/jumpcloud_bootstrap_template.sh
+++ b/jumpcloud_bootstrap_template.sh
@@ -155,7 +155,7 @@ DEP_N_GATE_DONE="/var/tmp/com.jumpcloud.gate.done"
 
 CLIENT="mdm-zero-touch"
 VERSION="3.1.0"
-USER_AGENT="JumpCloud/${CLIENT}/${VERSION}"
+USER_AGENT="JumpCloud_${CLIENT}/${VERSION}"
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # END Script Variables                                                        ~


### PR DESCRIPTION
change the user agent naming convention from a slash to an underscore for consistency across products