### PR TITLE
Fix "Self ID" validation test

### DIFF
--- a/automation scripts/pue_verify.py
+++ b/automation scripts/pue_verify.py
@@ -87,7 +87,7 @@ class text_PUE(unittest.TestCase):
 
     def test_f1(self):
         '''Test Self ID'''
-        string = "self_ID="
+        string = "SELF_ID="
         regex = "^(%s)(\"(.*?)\")$" % string
         with open(text_PUE.script, "r") as file:
             match_list = []


### PR DESCRIPTION
The regex string currently used to validate the `SELF_ID="CE"` variable does not match the actual variable name due to a letter case mismatch, which causes the following results despite the value being correct:

```sh
$ python3 test_runner.py
test_a1_existence (pue_verify.text_PUE)
Test File Path ... ok
test_d3 (pue_verify.text_PUE)
String Validation ... ok
test_e1 (pue_verify.text_PUE)
Boolean Validation ... ok
test_f1 (pue_verify.text_PUE)
Test Self ID ... FAIL
test_a1_existence (postinstall_verify.text_POST)
Test File Path ... ok
test_b1_valid_strings (postinstall_verify.text_POST)
Testing postinstall script User Vars ... ok

======================================================================
FAIL: test_f1 (pue_verify.text_PUE)
Test Self ID
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/luis.ramos/go/src/github.com/TheJumpCloud/MDM-Prestage-User-Enrollment/automation scripts/pue_verify.py", line 100, in test_f1
    self.assertIsNot(len(match_list), 0, "Variable not found with regex search")
AssertionError: unexpectedly identical: 0 : Variable not found with regex search

----------------------------------------------------------------------
Ran 6 tests in 0.045s

FAILED (failures=1)
```

The proposed change fixes the failing test.