### PR TITLE
Sa 1211 jw openssl version fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 3.1.2
+
+### RELEASE DATE
+
+June 4, 2020
+
+#### RELEASE NOTES
+
+Update in script template to specifically use the built in version of OpenSSL in the Encryption and Decryption step of the script. Other versions of OpenSSL may encrypt or decrypt the API Key differently. To ensure the encrypted key can be decrypted by an out-of-the-box macOS system, using the openssl binary located in /usr/bin is necessary.
+
+This patch update will not affect current customers who have successfully encrypted and decrypted their API key.
+
 ## 3.1.1
 
 ### RELEASE DATE

--- a/jumpcloud_bootstrap_template.sh
+++ b/jumpcloud_bootstrap_template.sh
@@ -2,7 +2,7 @@
 
 #*******************************************************************************
 #
-#       Version 3.1.1 | See the CHANGELOG.md for version information
+#       Version 3.1.2 | See the CHANGELOG.md for version information
 #
 #       See the ReadMe file for detailed configuration steps.
 #
@@ -154,7 +154,7 @@ DEP_N_GATE_DONE="/var/tmp/com.jumpcloud.gate.done"
 #*******************************************************************************
 
 CLIENT="mdm-zero-touch"
-VERSION="3.1.1"
+VERSION="3.1.2"
 USER_AGENT="JumpCloud_${CLIENT}/${VERSION}"
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/jumpcloud_bootstrap_template.sh
+++ b/jumpcloud_bootstrap_template.sh
@@ -106,14 +106,14 @@ SELF_PASSWD=false
 function EncryptKey() {
     # Usage: EncryptKey "API_KEY" "DECRYPT_USER_UID" "ORG_ID"
     local ENCRYPTION_KEY=${2}${3}
-    local ENCRYPTED_KEY=$(echo "${1}" | openssl enc -e -base64 -A -aes-128-ctr -nopad -nosalt -k ${ENCRYPTION_KEY})
+    local ENCRYPTED_KEY=$(echo "${1}" | /usr/bin/openssl enc -e -base64 -A -aes-128-ctr -nopad -nosalt -k ${ENCRYPTION_KEY})
     echo "Encrypted key: ${ENCRYPTED_KEY}"
 }
 
 # Used to decrypt $ENCRYPTED_KEY
 function DecryptKey() {
     # Usage: DecryptKey "ENCRYPTED_KEY" "DECRYPT_USER_UID" "ORG_ID"
-    echo "${1}" | openssl enc -d -base64 -aes-128-ctr -nopad -A -nosalt -k "${2}${3}"
+    echo "${1}" | /usr/bin/openssl enc -d -base64 -aes-128-ctr -nopad -A -nosalt -k "${2}${3}"
 }
 
 # Resets DEPNotify


### PR DESCRIPTION
Which version of OpenSSL are you running? If a developer manages their own version of OpenSSL, it could be a different version than the binary app sitting in /usr/bin/openssl. Documentation in the wiki added to point admins to the /usr/bin/openssl application to encrypt and decrypt the API Key. 

Specify /usr/bin/openssl instead of assuming the version of openssl is the same across systems.