### PR TITLE
Sa 1940 validate daemon

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+## Issues
+* [<jira-id>](https://jumpcloud.atlassian.net/browse/<jira-id>) - <jira-title>
+
+## What does this solve?
+
+## Is there anything particularly tricky?
+
+## How should this be tested?
+
+## Screenshots

--- a/jumpcloud_bootstrap_template.sh
+++ b/jumpcloud_bootstrap_template.sh
@@ -2,7 +2,7 @@
 
 #*******************************************************************************
 #
-#       Version 3.1.3 | See the CHANGELOG.md for version information
+#       Version 3.1.4 | See the CHANGELOG.md for version information
 #
 #       See the ReadMe file for detailed configuration steps.
 #
@@ -154,7 +154,7 @@ DEP_N_GATE_DONE="/var/tmp/com.jumpcloud.gate.done"
 #*******************************************************************************
 
 CLIENT="mdm-zero-touch"
-VERSION="3.1.3"
+VERSION="3.1.4"
 USER_AGENT="JumpCloud_${CLIENT}/${VERSION}"
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1199,8 +1199,13 @@ if [[ -f $DEP_N_GATE_DONE ]]; then
     fi
     # Clean up steps
     echo "$(date "+%Y-%m-%d %H:%M:%S"): Status: Removing LaunchDaemon" >>"$DEP_N_DEBUG"
-    # Remove the LaunchDaemon file
-    rm -rf "/Library/LaunchDaemons/${DAEMON}"
+    # Remove the LaunchDaemon file if it exists
+    if [[ -f "/Library/LaunchDaemons/${DAEMON}" ]]; then
+        rm -rf "/Library/LaunchDaemons/${DAEMON}"
+        echo "$(date "+%Y-%m-%d %H:%M:%S"): Status: LaunchDaemon Removed" >>"$DEP_N_DEBUG"
+    else
+        echo "$(date "+%Y-%m-%dT%H:%M:%S"): Warning: Could not find/ remove LaunchDaemon" >>"$DEP_N_DEBUG"
+    fi
     # Clean up receipts
     rm /var/tmp/com.jumpcloud*
     # Make script delete itself


### PR DESCRIPTION
## Issues
* [SA-1940](https://jumpcloud.atlassian.net/browse/SA-9040) - Validate launch daemon before removing

## What does this solve?
If the script is configured improperly, specifically if the launch daemon is named incorrectly it will not "exist" in the specified location. Previously the prestange enrollment script would remove the entire Launch Daemons directory in this instance. This fix validates that the daemon exists before removing it. If the daemon does not exist the script will not remove any file in that location.
