### PR TITLE
Sa 2379 remove python2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 3.1.5
+
+### RELEASE DATE
+
+February 04, 2022
+
+#### RELEASE NOTES
+
+Remove Python call to get active user, in 12.3 python will no longer be shipped with macOS. Regular bash commands can be substituted here to provide compatibility moving forward.
 ## 3.1.3
 
 ### RELEASE DATE

--- a/jumpcloud_bootstrap_template.sh
+++ b/jumpcloud_bootstrap_template.sh
@@ -2,7 +2,7 @@
 
 #*******************************************************************************
 #
-#       Version 3.1.4 | See the CHANGELOG.md for version information
+#       Version 3.1.5 | See the CHANGELOG.md for version information
 #
 #       See the ReadMe file for detailed configuration steps.
 #
@@ -144,6 +144,10 @@ DEP_N_GATE_INSTALLJC="/var/tmp/com.jumpcloud.gate.installjc"
 DEP_N_GATE_SYSADD="/var/tmp/com.jumpcloud.gate.sysadd"
 DEP_N_GATE_UI="/var/tmp/com.jumpcloud.gate.ui"
 DEP_N_GATE_DONE="/var/tmp/com.jumpcloud.gate.done"
+# System Versions
+MacOSMajorVersion=$(sw_vers -productVersion | cut -d '.' -f 1)
+MacOSMinorVersion=$(sw_vers -productVersion | cut -d '.' -f 2)
+MacOSPatchVersion=$(sw_vers -productVersion | cut -d '.' -f 3)
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # END Script Variables                                                        ~
@@ -154,7 +158,7 @@ DEP_N_GATE_DONE="/var/tmp/com.jumpcloud.gate.done"
 #*******************************************************************************
 
 CLIENT="mdm-zero-touch"
-VERSION="3.1.4"
+VERSION="3.1.5"
 USER_AGENT="JumpCloud_${CLIENT}/${VERSION}"
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Issues
* [SA-2379](https://jumpcloud.atlassian.net/browse/SA-2379) - Replace python w/ bash expressions

## What does this solve?

12.3 versions of macOS will no longer ship python2.x - this PR addresses this change and replaces all python expressions to get the active user with their regular bash equivalent.

## Is there anything particularly tricky?

No

## How should this be tested?

In a macOS Monterey VM, run the compiled package. The prestage enrollment should continue as expected without error 

## Screenshots