### PR TITLE
Sa 2873 log timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 3.1.6
+
+### RELEASE DATE
+
+September 30, 2022
+
+#### RELEASE NOTES
+
+Update TimeStamp Format to account for agent logging changes in newer versions of the JumpCloud Agent.
+
 ## 3.1.5
 
 ### RELEASE DATE

--- a/jumpcloud_bootstrap_template.sh
+++ b/jumpcloud_bootstrap_template.sh
@@ -1016,7 +1016,7 @@ if [[ ! -f $DEP_N_GATE_DONE ]]; then
     now=$(date "+%y/%m/%d %H:%M:%S")
     # Get last line of the JumpCloud Agent
     lstLine=$(tail -1 /var/log/jcagent.log)
-    regexLine='([0-9][0-9])/([0-9][0-9])/([0-9][0-9]) ([0-9][0-9]:[0-9][0-9]:[0-9][0-9])'
+    regexLine='([0-9][0-9])-([0-9][0-9])-([0-9][0-9]) ([0-9][0-9]:[0-9][0-9]:[0-9][0-9])'
     if [[ $lstLine =~ $regexLine ]]; then
         # Get the time form the agent log
         lstTime=${BASH_REMATCH[0]}
@@ -1025,7 +1025,7 @@ if [[ ! -f $DEP_N_GATE_DONE ]]; then
     echo "$(date "+%Y-%m-%d %H:%M:%S"): JCAgent Last Log Time     : $lstTime" >>"$DEP_N_DEBUG"
     # convert to Epoch time
     nowEpoch=$(date -j -f "%y/%m/%d %T" "${now}" +'%s')
-    jclogEpoch=$(date -j -f "%y/%m/%d %T" "${lstTime}" +'%s')
+    jclogEpoch=$(date -j -f "%y-%m-%d %T" "${lstTime}" +'%s')
     echo "$(date "+%Y-%m-%d %H:%M:%S"): Current System Epoch Time : $nowEpoch" >>"$DEP_N_DEBUG"
     echo "$(date "+%Y-%m-%d %H:%M:%S"): Last JCAgent Epoch Time   : $jclogEpoch" >>"$DEP_N_DEBUG"
     # get the difference in time
@@ -1039,11 +1039,11 @@ if [[ ! -f $DEP_N_GATE_DONE ]]; then
         groupSwitchCheck=$(sed -n ''${logLines}',$p' /var/log/jcagent.log)
         groupTakeOverCheck=$(echo ${groupSwitchCheck} | grep "Processing user updates")
         lstLine=$(tail -1 /var/log/jcagent.log)
-        regexLine='([0-9][0-9])/([0-9][0-9])/([0-9][0-9]) ([0-9][0-9]:[0-9][0-9]:[0-9][0-9])'
+        regexLine='([0-9][0-9])-([0-9][0-9])-([0-9][0-9]) ([0-9][0-9]:[0-9][0-9]:[0-9][0-9])'
         if [[ $lstLine =~ $regexLine ]]; then
             lstTime=${BASH_REMATCH[0]}
         fi
-        jclogEpoch=$(date -j -f "%y/%m/%d %T" "${lstTime}" +'%s')
+        jclogEpoch=$(date -j -f "%y-%m-%d %T" "${lstTime}" +'%s')
                 now=$(date "+%y/%m/%d %H:%M:%S")
                 nowEpoch=$(date -j -f "%y/%m/%d %T" "${now}" +'%s')
                 epochDiff=$(( (nowEpoch - jclogEpoch) ))

--- a/jumpcloud_bootstrap_template.sh
+++ b/jumpcloud_bootstrap_template.sh
@@ -2,7 +2,7 @@
 
 #*******************************************************************************
 #
-#       Version 3.1.5 | See the CHANGELOG.md for version information
+#       Version 3.1.6 | See the CHANGELOG.md for version information
 #
 #       See the ReadMe file for detailed configuration steps.
 #
@@ -158,7 +158,7 @@ MacOSPatchVersion=$(sw_vers -productVersion | cut -d '.' -f 3)
 #*******************************************************************************
 
 CLIENT="mdm-zero-touch"
-VERSION="3.1.5"
+VERSION="3.1.6"
 USER_AGENT="JumpCloud_${CLIENT}/${VERSION}"
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Issues
* [SA-2873](https://jumpcloud.atlassian.net/browse/SA-2873) - Update TimeStamps

## What does this solve?

Newer versions of the JumpCloud agent have changed the format in which the timestamps are generated, this release updates the MDM Prestage User Enrollment script to look for these updated timestamps. 
