### PR TITLE
openSSL digest specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 3.1.7
+
+### RELEASE DATE
+
+November 03, 2022
+
+#### RELEASE NOTES
+
+Between MacOS Ventura and Monterey, the version of OpenSSL was updated. In Monterey systems and below, the shipped versions of OpenSSL used the MD5 digest by default for encoding/ decoding strings. In Ventura that default changed. This release specifies that the encryption/ decryption functions should use the MD5 digest thus ensuring compatibility of this script between OS versions of MacOS.
+
 ## 3.1.6
 
 ### RELEASE DATE

--- a/README.md
+++ b/README.md
@@ -10,6 +10,22 @@ With the aim to Make Work Happen&trade;, the MDM-Prestage-User-Enrollment workfl
 
 An implementation of the MDM-Prestage-User-Enrollment workflow allows JumpCloud admins to deploy company-owned, MacOS computers to employees around the globe before ever opening the box.
 
+## MacOS Ventura Note/ Future Support
+
+If you have been using this tool in previous versions of macOS, please note that the default version of openssl on mac has changed. The latest version of this script was updated to support Ventura's version of LibreSSL. Please merge your changes from this release into your script if you wish to continue using this script on Ventura systems.
+
+### Future macOS compatibility
+
+With other MDM vendors taking advantage of SSO authentication during enrollment, it's unlikely this script has much of a use case nor will it see much future development. As is the case with JAMF, enabling JumpCloud SSO authentication during enrollment will assign the first user of the system to be the username of JumpCloud user who authenticated during enrollment (assuming your `usernames` match the email convention i.e. username = `username` & email = `username`@domain.com).
+
+This workflow essentially negates the need for the entirety of this script.
+
+A post enrollment script can be used then to:
+
+- [Install the JumpCloud Agent Silently]()
+- Search JumpCloud users by username on system
+- [Assign the authenticated user to the system](https://docs.jumpcloud.com/api/2.0/index.html#tag/Users/operation/graph_userAssociationsPost)
+
 ## How does it work
 
 <p align="center">

--- a/jumpcloud_bootstrap_template.sh
+++ b/jumpcloud_bootstrap_template.sh
@@ -2,7 +2,7 @@
 
 #*******************************************************************************
 #
-#       Version 3.1.6 | See the CHANGELOG.md for version information
+#       Version 3.1.7 | See the CHANGELOG.md for version information
 #
 #       See the ReadMe file for detailed configuration steps.
 #
@@ -106,14 +106,14 @@ SELF_PASSWD=false
 function EncryptKey() {
     # Usage: EncryptKey "API_KEY" "DECRYPT_USER_UID" "ORG_ID"
     local ENCRYPTION_KEY=${2}${3}
-    local ENCRYPTED_KEY=$(echo "${1}" | /usr/bin/openssl enc -e -base64 -A -aes-128-ctr -nopad -nosalt -k ${ENCRYPTION_KEY})
+    local ENCRYPTED_KEY=$(echo "${1}" | /usr/bin/openssl enc -e -base64 -A -aes-128-ctr -md md5 -nopad -nosalt -k ${ENCRYPTION_KEY})
     echo "Encrypted key: ${ENCRYPTED_KEY}"
 }
 
 # Used to decrypt $ENCRYPTED_KEY
 function DecryptKey() {
     # Usage: DecryptKey "ENCRYPTED_KEY" "DECRYPT_USER_UID" "ORG_ID"
-    echo "${1}" | /usr/bin/openssl enc -d -base64 -aes-128-ctr -nopad -A -nosalt -k "${2}${3}"
+    echo "${1}" | /usr/bin/openssl enc -d -base64 -aes-128-ctr -md md5 -nopad -A -nosalt -k "${2}${3}"
 }
 
 # Resets DEPNotify
@@ -158,7 +158,7 @@ MacOSPatchVersion=$(sw_vers -productVersion | cut -d '.' -f 3)
 #*******************************************************************************
 
 CLIENT="mdm-zero-touch"
-VERSION="3.1.6"
+VERSION="3.1.7"
 USER_AGENT="JumpCloud_${CLIENT}/${VERSION}"
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Issues
* [SA-2989](https://jumpcloud.atlassian.net/browse/SA-2989) - OpenSSL Digest MD5

## What does this solve?

In macOS Ventura, the shipped version of openSSL uses a different default digest than previous versions. Encrypted strings with mismatched digests will not decode properly which would result in failed enrollments in this project. 

This release specifies the MD5 digest during encryption/ decryption of the API KEY. You do not need to change your encrypted key in this release, just update the encrypt/ decrypt functions in order for macOS Ventura systems to be able to decrypt your existing encrypted key.

## Is there anything particularly tricky?

## How should this be tested?

Validate the encryption and decryption functions. When specifying an API_KEY, USER_UID and ORG_ID, the encryption & decryption functions should return the same results on Ventura & Monterey systems.

```bash
#!/bin/bash
function EncryptKey() {
    local ENCRYPTION_KEY=${2}${3}
    # echo "${ENCRYPTION_KEY}"
    # local ENCRYPTED_KEY=$(echo "${1}" | /usr/bin/openssl enc -e -base64 -A -aes-256-cbc -md md5 -k ${ENCRYPTION_KEY})
    local ENCRYPTED_KEY=$(echo "${1}" | /usr/bin/openssl enc -e -base64 -A -aes-128-ctr -md md5 -nopad -nosalt -k ${ENCRYPTION_KEY})
    echo "${ENCRYPTED_KEY}"
}
ENCRYPTED_KEY=$(EncryptKey "API_KEY" "DECRYPT_USER_UID" "ORG_ID")
echo "_____"
echo "${ENCRYPTED_KEY}"
function DecryptKey() {
    # Usage: DecryptKey "ENCRYPTED_KEY" "DECRYPT_USER_UID" "ORG_ID"
    # echo "${1}" | /usr/bin/openssl enc -d -base64 -aes-256-cbc -md md5 -A -k "${2}${3}"
    echo "${1}" | /usr/bin/openssl enc -d -base64 -aes-128-ctr -md md5 -nopad -A -nosalt -k "${2}${3}"
}
DecryptKey "${ENCRYPTED_KEY}" "DECRYPT_USER_UID" "ORG_ID"
```

## Screenshots
macOS Ventura — LibreSSL 3.3.6 (default version)
![Screen Shot 2022-11-03 at 9 32 34 AM](https://user-images.githubusercontent.com/54448601/199764779-f42b4f20-9260-4fb7-aed2-eb7f718b0cb4.png)

macOS Monterey — LibreSSL 2.8.3 (default version)
![Screen Shot 2022-11-03 at 9 32 49 AM](https://user-images.githubusercontent.com/54448601/199764745-bd300127-2669-42a0-956b-0278c21e8032.png)
