### PR TITLE
fail counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 3.1.8
+
+### RELEASE DATE
+
+March 20, 2023
+
+#### RELEASE NOTES
+
+Added a condition to the script to account for systems running the tool without a valid APIKEY. Systems in this state were errantly attempting to query the API and would never succeed. If systems are caught in this state, the script will log an error and delete the `jumpcloud_bootstrap_template.sh` script.
+
 ## 3.1.7
 
 ### RELEASE DATE


### PR DESCRIPTION
## Issues
* [SA-3231](https://jumpcloud.atlassian.net/browse/SA-3231) - Remove Excess Logs on failed deployments

## What does this solve?

Systems running this tool can decrypt their API key halfway through their enrollment process. In previous versions of the automation it was possible for systems to get in a state with a non-null but invalid API key. The admin could deploy the script with a bad encrypted key, they could setup the workflow incorrectly or a myriad of other possibilities. 

It was possible at one point for a system to have a non-valid key and to enter an infinite loop (as the processes is loaded via a launchDaemon) and consistently try to query user group membership through the JumpCloud API. 

This release will attempt to detect systems in this state, if systems do not return a success when querying our API 4 times, the script will delete itself and log an error. This will prevent excess and unhelpful calls to our API and end the script process on the device itself. 

## Screenshots

[SA-3231]: https://jumpcloud.atlassian.net/browse/SA-3231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ