### PR TITLE
Sa 3426 enrollment post agent secure token protection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@
 
 ### RELEASE DATE
 
-July 12, 2023
+July 27, 2023
 
 #### RELEASE NOTES
 
 A change in the JumpCloud agent has affected how the MDM Prestage User Enrollment script completes it's enrollment. The JumpCloud Agent now requires that at least one Secure Token decorated user on a system exists. If the last Secure Token decorated user is unbound from the device, the user will persist and not be disabled to prevent scenarios where no Secure Token users are able to login. This change prevented the automatic logout of the Enrollment (Welcome) user. The Enrollment user was the last Secure Token user on the system.
 
 This version of the script changes the order in which the enrollment users (Welcome and Decrypt) are removed from the system. Instead of forcefully removing the users before the new user logs in. The script will prompt the user to login with their new account, forcefully log the enrollment user off, and wait until the new user has been granted Secure Token (which occurs on login authentication) before removing the enrollment users from the system.
+
+This version of the tool introduces a new mechanism for removing the enrollment users. A command is created in the JumpCloud organization and is scheduled to remove the enrollment users after the Zero Touch user logs in for the first time.
 
 ## 3.1.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 3.1.9
+
+### RELEASE DATE
+
+July 12, 2023
+
+#### RELEASE NOTES
+
+A change in the JumpCloud agent has affected how the MDM Prestage User Enrollment script completes it's enrollment. The JumpCloud Agent now requires that at least one Secure Token decorated user on a system exists. If the last Secure Token decorated user is unbound from the device, the user will persist and not be disabled to prevent scenarios where no Secure Token users are able to login. This change prevented the automatic logout of the Enrollment (Welcome) user. The Enrollment user was the last Secure Token user on the system.
+
+This version of the script changes the order in which the enrollment users (Welcome and Decrypt) are removed from the system. Instead of forcefully removing the users before the new user logs in. The script will prompt the user to login with their new account, forcefully log the enrollment user off, and wait until the new user has been granted Secure Token (which occurs on login authentication) before removing the enrollment users from the system.
+
 ## 3.1.8
 
 ### RELEASE DATE

--- a/jumpcloud_bootstrap_template.sh
+++ b/jumpcloud_bootstrap_template.sh
@@ -2,7 +2,7 @@
 
 #*******************************************************************************
 #
-#       Version 3.1.8 | See the CHANGELOG.md for version information
+#       Version 3.1.9 | See the CHANGELOG.md for version information
 #
 #       See the ReadMe file for detailed configuration steps.
 #
@@ -159,7 +159,7 @@ MacOSPatchVersion=$(sw_vers -productVersion | cut -d '.' -f 3)
 #*******************************************************************************
 
 CLIENT="mdm-zero-touch"
-VERSION="3.1.8"
+VERSION="3.1.9"
 USER_AGENT="JumpCloud_${CLIENT}/${VERSION}"
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Issues
* [SA-3426](https://jumpcloud.atlassian.net/browse/SA-3426) - Last Secure Token user not removed during MDM Prestage User Enrollment

## What does this solve?

A change in the JumpCloud agent resulted in enrollment hanging near the end of the process. Previously the enrollment and decryption users were removed from the system through a change in device association. This would leave the system in the state where no users were secure token ENABLED for a moment. Once the new authenticated user logged in for the first time they would become secure token ENABLED (instead of just ELIGIBLE).

The change in the JumpCloud agent would not allow the agent to remove all secure token ENABLED users (even if other users were ELIGIBLE).

**Before this change** the following users were expected to be on the system after the "someone.lastname" confirmed their identity.
User: Welcome (secure token ENABLED)
User: Decrypt (secure token ELIGIBLE)
User: someone.lastname@company.com (secure token ELIGIBLE)

To force a logout, the welcome, decrypt users were removed from their association to the system resulting in only "someone.lastname" being associated with the device.

The change in the agent prevented this since the "welcome" user was the only secure token ENABLED user.

**After this change** the following users were expected to be on the system after the "someone.lastname" confirmed their identity.
User: Welcome (secure token ENABLED)
User: Decrypt (secure token ELIGIBLE)
User: someone.lastname@company.com (secure token ELIGIBLE)

The daemon now forces a logout though means of a bash command and waits until the expected user "someone.lastname" logs in, once that happens the user table should look like this:
User: Welcome (secure token ENABLED & hidden)
User: Decrypt (secure token ELIGIBLE & hidden)
User: someone.lastname@company.com (secure token ENABLED)

At that point the daemon should remove the association for the welcome and decrypt user resulting in only the "someone.lastname" account left on the system. 

## Is there anything particularly tricky?

There are a number of "try/ catch" scenarios added to the body of the script. If the system is restarted, the script will attempt to use the System Context API to do a majority of the work. The inclusion of these lines allows for the system to do most of the requested work if it encounters an error through an unexpected reboot.

## How should this be tested?

1. On a system simulate the MDM enrollment with a secure token admin "welcome" user.
2. Build and install the package per the requirements in this project.
3. The system should begin enrollment enter the full screen setup and install the JumpCloud Agent.
4. The prompts should ask for a user to identify themselves.
5. Once that user has been associated with the system the enrollment prompts should inform the user that the login screen will pop up and to login as their new account.
6. (Test this on another instance, reboot at this stage, rebooting here shouldn't break the last three steps)
7. Upon login, the enrollment prompt should still continue and note that a few remaining items are being taken care of.
8. The user who enrolled themselves should be the only user left on the device, they should have secure token
9. The enrollment (welcome and decrypt) users should no longer be on the device, they should have been removed by a process and noted in the log.

## Screenshots

[SA-3426]: https://jumpcloud.atlassian.net/browse/SA-3426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ