### PR TITLE
CUT-4972: Update DEP URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 3.1.11
+
+### RELEASE DATE
+
+Dec 05, 2025
+
+#### RELEASE NOTES
+
+Updated the DEP URL to the correct URL.
+
 ## 3.1.10
 
 ### RELEASE DATE

--- a/jumpcloud_bootstrap_template.sh
+++ b/jumpcloud_bootstrap_template.sh
@@ -178,7 +178,7 @@ if [[ ! -f $DEP_N_GATE_INSTALLJC ]]; then
     caffeinatePID=$!
 
     # Install DEPNotify
-    curl --silent --output /tmp/DEPNotify-1.1.6.pkg "https://files.nomad.menu/DEPNotify.pkg" >/dev/null
+    curl --silent --output /tmp/DEPNotify-1.1.6.pkg "https://files.jamfconnect.com/DEPNotify.pkg" >/dev/null
     installer -pkg /tmp/DEPNotify-1.1.6.pkg -target /
 
     # Create DEPNotify log files


### PR DESCRIPTION
## Issues
* [CUT-4972](https://jumpcloud.atlassian.net/browse/CUT-4972) - Update DEP URL

## What does this solve?
Updates the DEP Url from `https://files.nomad.menu/DEPNotify.pkg` to `https://files.jamfconnect.com/DEPNotify.pkg`

## Is there anything particularly tricky?
N/A

## How should this be tested?
N/A

[CUT-4972]: https://jumpcloud.atlassian.net/browse/CUT-4972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ